### PR TITLE
Define this.current before checking its validation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -223,12 +223,12 @@
             onBeforeOpen = _settings2.onBeforeOpen,
             onOpen = _settings2.onOpen;
 
-        if (!(this.current instanceof HTMLElement === false)) {
+        this.releaseNode(this.current);
+        this.current = getElementContext(allMatches);
+        if (this.current instanceof HTMLElement === false) {
           throwError('VanillaModal target must exist on page.');
           return;
         }
-        this.releaseNode(this.current);
-        this.current = getElementContext(allMatches);
         if (typeof onBeforeOpen === 'function') {
           onBeforeOpen.call(this, e);
         }

--- a/index.js
+++ b/index.js
@@ -160,14 +160,9 @@ export default class VanillaModal {
   open(allMatches, e) {
     const { page } = this.dom;
     const { onBeforeOpen, onOpen } = this.settings;
-<<<<<<< HEAD
     this.releaseNode(this.current);
     this.current = getElementContext(allMatches);
     if (this.current instanceof HTMLElement === false) {
-=======
-    this.closeModal(e);
-    if (!(this.current instanceof HTMLElement === false)) {
->>>>>>> 6eada0bb49537a22f9844cb4244a9d548a41b8ea
       throwError('VanillaModal target must exist on page.');
       return;
     }

--- a/index.js
+++ b/index.js
@@ -160,12 +160,12 @@ export default class VanillaModal {
   open(allMatches, e) {
     const { page } = this.dom;
     const { onBeforeOpen, onOpen } = this.settings;
-    if (!(this.current instanceof HTMLElement === false)) {
+    this.releaseNode(this.current);
+    this.current = getElementContext(allMatches);
+    if (this.current instanceof HTMLElement === false) {
       throwError('VanillaModal target must exist on page.');
       return;
     }
-    this.releaseNode(this.current);
-    this.current = getElementContext(allMatches);
     if (typeof onBeforeOpen === 'function') {
       onBeforeOpen.call(this, e);
     }


### PR DESCRIPTION
Currently you cannot open when you already have an open modal. The reason is that the validation check `this.current instanceof HTMLElement === false` had a bang added to it and was moved before the current node was released and the new current node was defined. This causes the validation to pass when this.current is not an existing HTMLElement, but fail when it is, and it runs the validation on the existing this.current rather than the one about to be set.

This commit changes the code to the way it was in earlier commits, so the open method changes this.current before running a validation to check if this.current is a valid HTML element.