### PR TITLE
Issue #38 - modal can now be opened from a modal

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -352,6 +352,7 @@
         var matchedNode = matches(e, open);
         if (matchedNode) {
           e.preventDefault();
+          this.closeModal(e);
           this.open(matchedNode, e);
         }
       }

--- a/index.js
+++ b/index.js
@@ -279,6 +279,7 @@ export default class VanillaModal {
     const matchedNode = matches(e, open);
     if (matchedNode) {
       e.preventDefault();
+      this.closeModal(e);
       this.open(matchedNode, e);
     }
   }


### PR DESCRIPTION
I didn't see the message from @markjanzer saying that there was already an open Pull Request (https://github.com/benceg/vanilla-modal/pull/32) that fixes this issue. 

The PR I've added is a different approach to accomplishing the same thing.  Instead of changing the checks the open model is forced close before the new one is opened.  The nice thing about this approach is that the checks can stay in place.