### PR TITLE
issue #38 - fixing bug where modal within a modal can't be opened

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -223,6 +223,7 @@
             onBeforeOpen = _settings2.onBeforeOpen,
             onOpen = _settings2.onOpen;
 
+        this.closeModal(e);
         if (!(this.current instanceof HTMLElement === false)) {
           throwError('VanillaModal target must exist on page.');
           return;

--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ export default class VanillaModal {
   open(allMatches, e) {
     const { page } = this.dom;
     const { onBeforeOpen, onOpen } = this.settings;
+    this.closeModal(e);
     if (!(this.current instanceof HTMLElement === false)) {
       throwError('VanillaModal target must exist on page.');
       return;


### PR DESCRIPTION
I made this PR before seeing the fix for #32 by @markjanzer.  It's a different approach than Marks in that it simply closes the modal before opening the next one.  

The advantage being that the checks that existed can stay in place. 

One note is that the closeModal method was used instead of the close method because the closeModalWithTransition method would create a race condition.  I think most users however would prefer to have as small a transition between modals as possible, so I don't see this as an issue.